### PR TITLE
Update installer URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,7 @@
 echo Downloading the CLI installer
 
 DOWNLOADER=$(which curl)
-$DOWNLOADER -s https://dot.net/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
+$DOWNLOADER -s https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
 chmod +x "$ASDF_INSTALL_PATH/dotnet-install.sh"
 


### PR DESCRIPTION
Updates dotnet-install.sh installer URL to the new one. The `-L` option is not provided to cURL so it would fail to follow the redirect. Probably best to keep it that way for security.