### PR TITLE
fix download `dotnet-install.sh` fail on macOS.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,12 @@
 echo Downloading the CLI installer
 
 DOWNLOADER=$(which curl)
-$DOWNLOADER -s https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
+
+# append `-SL` also works, but follow [official document](https://docs.microsoft.com/zh-cn/dotnet/core/tools/dotnet-install-script) maybe more best.
+# $DOWNLOADER -sSL https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
+
+# ref: https://docs.microsoft.com/zh-cn/dotnet/core/tools/dotnet-install-script
+$DOWNLOADER -sSL https://dot.net/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
 chmod +x "$ASDF_INSTALL_PATH/dotnet-install.sh"
 


### PR DESCRIPTION
https://docs.microsoft.com/zh-cn/dotnet/core/tools/dotnet-install-script

```bash
curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
```