### PR TITLE
Use STS instead of Current

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -13,7 +13,7 @@ chmod +x "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
 echo Installing the CLI requested version $ASDF_INSTALL_VERSION. Please wait, installation may take a few minutes.
 
-"$ASDF_INSTALL_PATH/dotnet-install.sh" --install-dir "$ASDF_INSTALL_PATH" --channel Current --version "$ASDF_INSTALL_VERSION" --no-path
+"$ASDF_INSTALL_PATH/dotnet-install.sh" --install-dir "$ASDF_INSTALL_PATH" --channel STS --version "$ASDF_INSTALL_VERSION" --no-path
 
 rm "$ASDF_INSTALL_PATH/dotnet-install.sh"
 


### PR DESCRIPTION
It's because `Current` is deprecated

```bash
$ asdf install
Downloading the CLI installer
Installing the CLI requested version 6.0.302. Please wait, installation may take a few minutes.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet_install: Warning: Value "Current" is deprecated for -Channel option. Use "STS" instead.
```