### PR TITLE
set DOTNET_ROOT in exec_env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+asdf_update_dotnet_home() {
+  local dotnet_path
+  dotnet_path="$(rtx which dotnet 2> /dev/null  )"
+  if [[ -n "${dotnet_path}" ]]; then
+    export DOTNET_ROOT
+    DOTNET_ROOT="$(dirname "$(realpath "${dotnet_path}")")"
+  fi
+}
+
+prompt_command() {
+  asdf_update_dotnet_home
+}
+
+asdf_update_dotnet_home


### PR DESCRIPTION
Use exec-env [1] to set DOTNET_ROOT.
Proposed following a discussion with the maintainer of rtx [2].


1: https://asdf-vm.com/plugins/create.html#bin-exec-env
2: https://github.com/jdxcode/rtx/issues/435