### PR TITLE
Fixes #38 defaulting to the "STS" channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ asdf plugin-add dotnet-core https://github.com/emersonsoares/asdf-dotnet-core.gi
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of .Net Core.
 
+You can specify a DotNet installation channel by setting up the `DEFAULT_DOTNET_CORE_CHANNEL` environment variable
+that defaults to `STS` (Standard-Term Support)
+
+```
+DEFAULT_DOTNET_CORE_CHANNEL="LTS" asdf install dotnet-core latest
+```
+
+See https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core for more information.
+
 ## DOTNET_ROOT
 To set DOTNET_ROOT in your shell's initialization add the following:
 

--- a/bin/install
+++ b/bin/install
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
-echo Downloading the CLI installer
+
+# Set default channel to STS if not provided
+DEFAULT_CHANNEL=${DEFAULT_DOTNET_CORE_CHANNEL:-STS}
+
+echo "Downloading the CLI installer"
 
 DOWNLOADER=$(which curl)
 
-# append `-SL` also works, but follow [official document](https://docs.microsoft.com/zh-cn/dotnet/core/tools/dotnet-install-script) maybe more best.
-# $DOWNLOADER -sSL https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
-
-# ref: https://docs.microsoft.com/zh-cn/dotnet/core/tools/dotnet-install-script
+# Download the .NET install script
 $DOWNLOADER -sSL https://dot.net/v1/dotnet-install.sh > "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
 chmod +x "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
-echo Installing the CLI requested version $ASDF_INSTALL_VERSION. Please wait, installation may take a few minutes.
+echo "Installing the CLI requested version $ASDF_INSTALL_VERSION. Please wait, installation may take a few minutes."
 
-"$ASDF_INSTALL_PATH/dotnet-install.sh" --install-dir "$ASDF_INSTALL_PATH" --channel Current --version "$ASDF_INSTALL_VERSION" --no-path
+# Run the .NET install script with the specified or default channel
+"$ASDF_INSTALL_PATH/dotnet-install.sh" --install-dir "$ASDF_INSTALL_PATH" --channel $DEFAULT_CHANNEL --version "$ASDF_INSTALL_VERSION" --no-path
 
+# Clean up the install script
 rm "$ASDF_INSTALL_PATH/dotnet-install.sh"
 
-if [ $? -ne 0 ]
-then
-    echo Download of $ASDF_INSTALL_VERSION version of the CLI failed. Exiting now.
-    exit 0
+# Check if installation was successful
+if [ $? -ne 0 ]; then
+    echo "Download of version $ASDF_INSTALL_VERSION of the CLI failed. Exiting now."
+    exit 1
 fi
-echo The CLI has been installed.
+
+echo "The CLI has been installed."
+


### PR DESCRIPTION
  * The new DEFAULT_DOTNET_CORE_CHANNEL environment variable is now supported. Options are "STS", "LTS" and others.